### PR TITLE
adds order to demographics

### DIFF
--- a/Modules/Ministry/app/Http/Controllers/MaintenanceController.php
+++ b/Modules/Ministry/app/Http/Controllers/MaintenanceController.php
@@ -507,7 +507,7 @@ class MaintenanceController extends Controller
     public function demographicsList(Request $request): \Inertia\Response
     {
         $demographics = Demographic::with('options')
-            ->orderBy('question', 'asc')
+            ->ordered()
             ->get();
 
         return Inertia::render('Ministry::Maintenance', [

--- a/Modules/Ministry/app/Http/Controllers/StudentController.php
+++ b/Modules/Ministry/app/Http/Controllers/StudentController.php
@@ -46,8 +46,8 @@ class StudentController extends Controller
         
         // Load active demographics with their options
         $demographics = Demographic::with('options')
-            ->where('active', true)
-            ->orderBy('question', 'asc')
+            ->active()
+            ->ordered()
             ->get();
 
         // Get existing demographic answers for this student

--- a/Modules/Ministry/resources/assets/js/Components/MaintenanceDemographics.vue
+++ b/Modules/Ministry/resources/assets/js/Components/MaintenanceDemographics.vue
@@ -91,6 +91,7 @@
                                         <p><strong>Type:</strong> {{ demographic.type }}</p>
                                         <p><strong>Required:</strong> {{ demographic.required ? 'Yes' : 'No' }}</p>
                                         <p><strong>Active:</strong> {{ demographic.active ? 'Yes' : 'No' }}</p>
+                                        <p><strong>Order:</strong> {{ demographic.order || 0 }}</p>
                                         <p v-if="demographic.description"><strong>Description:</strong> {{ demographic.description }}</p>
                                         <div class="mt-3">
                                             <button @click="editDemographic(demographic)" type="button" 
@@ -148,6 +149,10 @@
                                         <option value="false">No</option>
                                         <option value="true">Yes</option>
                                     </BreezeSelect>
+                                </div>
+                                <div class="col-md-3">
+                                    <BreezeLabel for="newDemographicOrder" class="form-label" value="Order" />
+                                    <BreezeInput type="number" class="form-control" id="newDemographicOrder" v-model="newDemographicForm.order" min="0" />
                                 </div>
                                 <div class="col-12">
                                     <BreezeLabel for="newDemographicDescription" class="form-label" value="Description" />
@@ -212,6 +217,10 @@
                                         <option value="false">No</option>
                                         <option value="true">Yes</option>
                                     </BreezeSelect>
+                                </div>
+                                <div class="col-md-3">
+                                    <BreezeLabel for="editDemographicOrder" class="form-label" value="Order" />
+                                    <BreezeInput type="number" class="form-control" id="editDemographicOrder" v-model="editDemographicForm.order" min="0" />
                                 </div>
                                 <div class="col-12">
                                     <BreezeLabel for="editDemographicDescription" class="form-label" value="Description" />
@@ -358,7 +367,8 @@ export default {
                 description: '',
                 type: '',
                 required: false,
-                active: true
+                active: true,
+                order: 0
             },
             newOptionFormData: {
                 demographic_id: '',

--- a/Modules/Student/app/Http/Controllers/DemographicSharingController.php
+++ b/Modules/Student/app/Http/Controllers/DemographicSharingController.php
@@ -33,7 +33,7 @@ class DemographicSharingController extends Controller
                         ->with('answers');
                 }
             ])
-            ->orderBy('question')
+            ->ordered()
             ->get();
 
         // Get all active shareable entities

--- a/Modules/Student/app/Http/Controllers/StudentController.php
+++ b/Modules/Student/app/Http/Controllers/StudentController.php
@@ -27,8 +27,8 @@ class StudentController extends Controller
         
         // Load active demographics with their options
         $demographics = Demographic::with('options')
-            ->where('active', true)
-            ->orderBy('question', 'asc')
+            ->active()
+            ->ordered()
             ->get();
 
         // Get existing demographic answers for this student
@@ -113,8 +113,8 @@ class StudentController extends Controller
         
         // Load active demographics with their options
         $demographics = Demographic::with('options')
-            ->where('active', true)
-            ->orderBy('question', 'asc')
+            ->active()
+            ->ordered()
             ->get();
 
         // Get existing demographic answers for this student

--- a/app/Http/Requests/DemographicEditRequest.php
+++ b/app/Http/Requests/DemographicEditRequest.php
@@ -29,6 +29,7 @@ class DemographicEditRequest extends FormRequest
             'type.*' => 'Type is not valid.',
             'required.*' => 'Required field is not valid.',
             'active.*' => 'Active field is not valid.',
+            'order.*' => 'Order field is not valid.',
         ];
     }
 
@@ -45,6 +46,7 @@ class DemographicEditRequest extends FormRequest
             'type' => 'required|in:text,select,multi-select,radio,checkbox',
             'required' => 'required|boolean',
             'active' => 'required|boolean',
+            'order' => 'nullable|integer|min:0',
         ];
     }
 

--- a/app/Http/Requests/DemographicStoreRequest.php
+++ b/app/Http/Requests/DemographicStoreRequest.php
@@ -29,6 +29,7 @@ class DemographicStoreRequest extends FormRequest
             'type.*' => 'Type is not valid.',
             'required.*' => 'Required field is not valid.',
             'active.*' => 'Active field is not valid.',
+            'order.*' => 'Order field is not valid.',
         ];
     }
 
@@ -45,6 +46,7 @@ class DemographicStoreRequest extends FormRequest
             'type' => 'required|in:text,select,multi-select,radio,checkbox',
             'required' => 'required|boolean',
             'active' => 'required|boolean',
+            'order' => 'nullable|integer|min:0',
         ];
     }
 

--- a/app/Models/Demographic.php
+++ b/app/Models/Demographic.php
@@ -16,7 +16,7 @@ class Demographic extends Model
      *
      * @var array<int, string>
      */
-    protected $fillable = ['question', 'description', 'type', 'required', 'active'];
+    protected $fillable = ['question', 'description', 'type', 'required', 'active', 'order'];
 
     /**
      * The attributes that should be cast.
@@ -50,5 +50,13 @@ class Demographic extends Model
     public function scopeActive($query)
     {
         return $query->where('active', true);
+    }
+
+    /**
+     * Scope a query to order demographics by their order field.
+     */
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('order')->orderBy('question');
     }
 }

--- a/database/migrations/2025_07_17_165615_add_order_to_demographics_table.php
+++ b/database/migrations/2025_07_17_165615_add_order_to_demographics_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('demographics', function (Blueprint $table) {
+            $table->integer('order')->default(0);
+            $table->index(['order', 'active']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('demographics', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/js/app.js": "/js/app.js?id=f148a209ec73a9706a6371dbe37fe038",
+    "/js/app.js": "/js/app.js?id=e73c2ed54600bc53a8bbc4003dfc34e5",
     "/css/app.css": "/css/app.css?id=6a42095d8238638be4a8d612db3e24ea",
     "/images/2022/BC_PSEFS_H_CMYK_pos.png": "/images/2022/BC_PSEFS_H_CMYK_pos.png?id=d34e0966092a58e4f6b3395381f4ae0a",
     "/images/2022/BC_PSEFS_H_CMYK_rev.png": "/images/2022/BC_PSEFS_H_CMYK_rev.png?id=1bd8fccdd579fe5b96cb19b14c94366e",


### PR DESCRIPTION
This pull request introduces a new `order` field to the `Demographic` model, allowing demographics to be explicitly ordered. It includes changes to the database schema, model, controllers, validation rules, and front-end components to support this functionality. Additionally, existing queries for demographics have been refactored to use a new `ordered` scope for consistency.

### Backend Changes

* **Database Migration**: Added a new `order` column to the `demographics` table with a default value of `0` and an index on `order` and `active`. (`database/migrations/2025_07_17_165615_add_order_to_demographics_table.php`)
* **Model Updates**: Updated the `Demographic` model to include `order` in the `$fillable` array and added a new `scopeOrdered` method to order demographics by `order` and then by `question`. (`app/Models/Demographic.php`) [[1]](diffhunk://#diff-c417de3682b73eb7f4a8e31f4099b49d07fc8a905431bb40e53245568a14de2cL19-R19) [[2]](diffhunk://#diff-c417de3682b73eb7f4a8e31f4099b49d07fc8a905431bb40e53245568a14de2cR54-R61)
* **Validation Rules**: Updated the `DemographicStoreRequest` and `DemographicEditRequest` to include validation for the `order` field, ensuring it is an optional integer with a minimum value of `0`. (`app/Http/Requests/DemographicStoreRequest.php`, `app/Http/Requests/DemographicEditRequest.php`) [[1]](diffhunk://#diff-9b35dda94ae16dc5d9507a36b337e57c66bbe56bcccacfaa0e4d641c5377e60eR49) [[2]](diffhunk://#diff-54b38b77e90d15524f2ed7c6ae6a7a5573ebe3b8aadc0f90f9a0eddbd1c403a5R49)

### Controller Refactoring

* **Query Refactor**: Replaced `orderBy('question', 'asc')` and `where('active', true)` with the new `ordered` and `active` scopes in various controllers for consistency and readability. (`Modules/Ministry/app/Http/Controllers/MaintenanceController.php`, `Modules/Ministry/app/Http/Controllers/StudentController.php`, `Modules/Student/app/Http/Controllers/DemographicSharingController.php`) [[1]](diffhunk://#diff-7462ee5a5257a25c4c43988c5a10239ea93ab03f1281a1d6c0395fdb9c720fc1L510-R510) [[2]](diffhunk://#diff-dd24e96ea8f024bdeb71fa5c38f5012b0638ea1f8da9dfa0af09f8dac191d76fL49-R50) [[3]](diffhunk://#diff-cb9975be312f3333556a0ddfe17f1286ce0acd9866fff87c7e6ee950ba931629L36-R36) [[4]](diffhunk://#diff-beb2428d24f1d75359bc678b366aee1756536e7c603724543c147425c320a3a5L30-R31) [[5]](diffhunk://#diff-beb2428d24f1d75359bc678b366aee1756536e7c603724543c147425c320a3a5L116-R117)

### Front-End Updates

* **Demographic Display**: Added the `order` field to the demographic details view and forms in the `MaintenanceDemographics.vue` component. Users can now view and edit the order of demographics. (`Modules/Ministry/resources/assets/js/Components/MaintenanceDemographics.vue`) [[1]](diffhunk://#diff-77803e0bf6652921a3c4e93640e595d300e92c4c5e714a964743e609fd3fa943R94) [[2]](diffhunk://#diff-77803e0bf6652921a3c4e93640e595d300e92c4c5e714a964743e609fd3fa943R153-R156) [[3]](diffhunk://#diff-77803e0bf6652921a3c4e93640e595d300e92c4c5e714a964743e609fd3fa943R221-R224) [[4]](diffhunk://#diff-77803e0bf6652921a3c4e93640e595d300e92c4c5e714a964743e609fd3fa943L361-R371)

### Miscellaneous

* **Build Manifest Update**: Updated the `mix-manifest.json` file to reflect changes in the compiled assets. (`public/mix-manifest.json`)