### PR TITLE
requires demographics to submit application

### DIFF
--- a/Modules/Ministry/resources/assets/js/Components/StudentDemographics.vue
+++ b/Modules/Ministry/resources/assets/js/Components/StudentDemographics.vue
@@ -2,7 +2,7 @@
     <div v-if="demographics && demographics.length > 0" class="col-12">
         <hr />
         <h5 class="mb-3">Demographics Information:</h5>
-        <p><i>The information provided below is collected exclusively for reporting and evaluation purposes to help the Province better understand where funding is most needed. It will not impact your eligibility for grant funding. Participation is entirely voluntary, and you may choose not to answer any questions that you find uncomfortable. Please refer to the FAQ section for demographic information definitions.</i></p>
+        <p><i>The information provided below is collected exclusively for reporting and evaluation purposes to help the Province better understand where funding is most needed. It will not impact your eligibility for grant funding. Participation is entirely voluntary, and you may choose not to answer any questions that you find uncomfortable. Please refer to the FAQ page in the top banner for demographic information definitions.</i></p>
         
         <div class="row">
             <div v-for="demographic in demographics" :key="demographic.id" class="mb-3 col-md-6 col-sm-12">

--- a/Modules/Student/resources/assets/js/Components/StudentDemographics.vue
+++ b/Modules/Student/resources/assets/js/Components/StudentDemographics.vue
@@ -2,7 +2,7 @@
     <div v-if="demographics && demographics.length > 0" class="col-12">
         <hr />
         <h5 class="mb-3">Demographics Information:</h5>
-        <p><i>The information provided below is collected exclusively for reporting and evaluation purposes to help the Province better understand where funding is most needed. It will not impact your eligibility for grant funding. Participation is entirely voluntary, and you may choose not to answer any questions that you find uncomfortable. Please refer to the FAQ section for demographic information definitions.</i></p>
+        <p><i>The information provided below is collected exclusively for reporting and evaluation purposes to help the Province better understand where funding is most needed. It will not impact your eligibility for grant funding. Participation is entirely voluntary, and you may choose not to answer any questions that you find uncomfortable. Please refer to the FAQ page in the top banner for demographic information definitions.</i></p>
 
         <div class="row">
             <div v-for="demographic in demographics" :key="demographic.id" class="mb-3 col-md-6 col-sm-12">


### PR DESCRIPTION
This pull request updates the text in the `StudentDemographics.vue` component files for better clarity regarding the location of demographic information definitions. The change specifies that users can find the FAQ page in the "top banner" instead of the "FAQ section."

### Text clarification updates:

* [`Modules/Ministry/resources/assets/js/Components/StudentDemographics.vue`](diffhunk://#diff-5283b80bc2a9485a08165be78485a0fd8a2fcfae7a4416c2397614e69e6610f0L5-R5): Updated the instructional text to direct users to the "FAQ page in the top banner" for demographic information definitions.
* [`Modules/Student/resources/assets/js/Components/StudentDemographics.vue`](diffhunk://#diff-dff1af46c5b5e358d2523e910a3b497a4ba30e4178ecca631cc93d110ced9619L5-R5): Updated the instructional text to direct users to the "FAQ page in the top banner" for demographic information definitions.