### PR TITLE
Fix modal backdrop freeze issue on Claim updates

### DIFF
--- a/Modules/Ministry/app/Http/Controllers/ClaimController.php
+++ b/Modules/Ministry/app/Http/Controllers/ClaimController.php
@@ -118,7 +118,10 @@ class ClaimController extends Controller
         $claim = Claim::find($request->id);
         $id = $request->page === 'students' ? $claim->student->id : $claim->institution->id;
 
-        return Redirect::route('ministry.'.$request->page.'.index');
+        if ($request->page === 'claims') {
+            return Redirect::route('ministry.'.$request->page.'.index');
+        }
+        return Redirect::route('ministry.' . $request->page . '.show', [$id, $request->subpage]);
     }
 
     private function paginateClaimsByInstitution($institutionGuid)


### PR DESCRIPTION
#### Changes:
Keep users on the same tab after a claim update to prevent the backdrop freezing issue in the Ministry module