### PR TITLE
Dev

### DIFF
--- a/Modules/Institution/app/Http/Controllers/ClaimController.php
+++ b/Modules/Institution/app/Http/Controllers/ClaimController.php
@@ -143,7 +143,7 @@ class ClaimController extends Controller
 
         foreach ($data as $d) {
             $csvData[] = [$d->program->program_name, $d->sin, $d->first_name, $d->last_name, $d->dob, $d->email, $d->city,
-                $d->zip_code, $d->claim_status, $d->registration_fee, $d->materials_fee, $d->program_fee, $d->claim_percent, $d->program->funding_type,
+                $d->zip_code, $d->claim_status, $d->registration_fee, $d->materials_fee, $d->program_fee, $d->claim_percent, ($d->funding_type ?: optional($d->program)->funding_type),
                 $d->estimated_hold_amount, $d->correction_amount, $d->stable_enrolment_date, $d->expected_stable_enrolment_date,
                 $d->expiry_date, $d->claimed_by_name, $d->updated_at, $d->process_feedback, $d->outcome_effective_date, $d->outcome_status];
         }

--- a/Modules/Institution/app/Http/Controllers/InstitutionController.php
+++ b/Modules/Institution/app/Http/Controllers/InstitutionController.php
@@ -5,6 +5,7 @@ namespace Modules\Institution\Http\Controllers;
 use App\Events\StaffRoleChanged;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\InstitutionStaffEditRequest;
+use App\Models\AllocationFundingType;
 use App\Models\Claim;
 use App\Models\InstitutionStaff;
 use App\Models\ProgramYear;
@@ -43,98 +44,95 @@ class InstitutionController extends Controller
 
         $programYear = ProgramYear::where('guid', $cacheProgramYear['default'])->first();
 
-        // Eager load active allocation
+        // Load all active allocations for the program year (a program year may contain several).
         $institution->load(['allocations' => function ($query) use ($programYear) {
             $query->where('program_year_guid', $programYear->guid)->where('status', 'active');
             $query->orderByDesc('created_at');
         }]);
 
-        $instAllocation = $institution->allocations->first();
-        if (! is_null($instAllocation)) {
+        $claimPercent = (float) $programYear->claim_percent;
 
-    //         $claimCounts = Claim::where('institution_guid', $institution->guid)
-    //             ->where('allocation_guid', $instAllocation->guid)
-    //             ->selectRaw("
-    //     SUM(CASE WHEN claim_status = 'Claimed' THEN COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0) ELSE 0 END) as claimed,
-    //     SUM(CASE WHEN claim_status = 'Hold' THEN COALESCE(estimated_hold_amount, 0) ELSE 0 END) as hold
-    // ")
-    //             ->first();
+        // Adds the admin fee to a net claim amount so figures match the allocation accounting.
+        $withAdmin = function ($amount) use ($claimPercent) {
+            $amount = (float) $amount;
+            return ($claimPercent > 0 && $amount) ? $amount + ($amount / $claimPercent) : $amount;
+        };
 
-            
-            $gov_hold = Claim::where('institution_guid', $institution->guid)
-                ->where('allocation_guid', $instAllocation->guid)
-                ->where('claim_status', 'Hold')
-                ->whereHas('program', function($q) {
-                    $q->whereNull('funding_type')->orWhere('funding_type', '!=', 'Transferable Skills');
-                })
-                ->sum(\DB::raw('COALESCE(estimated_hold_amount, 0)'));
+        // Build a per-allocation, per-funding-type summary for the dashboard cards.
+        $allocationSummaries = $institution->allocations->map(function ($allocation) use ($institution, $withAdmin) {
+            $fundingTypes = AllocationFundingType::where('allocation_guid', $allocation->guid)
+                ->orderBy('funding_type')
+                ->get();
 
-            $gov_claimed = Claim::where('institution_guid', $institution->guid)
-                ->where('allocation_guid', $instAllocation->guid)
-                ->where('claim_status', 'Claimed')
-                ->whereHas('program', function($q) {
-                    $q->whereNull('funding_type')->orWhere('funding_type', '!=', 'Transferable Skills');
-                })
-                ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
+            // One card per funding type defined on this allocation.
+            $fundingTypeCards = $fundingTypes->map(function ($ft) use ($institution, $allocation, $withAdmin) {
+                $hold = Claim::where('institution_guid', $institution->guid)
+                    ->where('allocation_guid', $allocation->guid)
+                    ->where('claim_status', 'Hold')
+                    ->where('funding_type', $ft->funding_type)
+                    ->sum(\DB::raw('COALESCE(estimated_hold_amount, 0)'));
 
+                $claimed = Claim::where('institution_guid', $institution->guid)
+                    ->where('allocation_guid', $allocation->guid)
+                    ->where('claim_status', 'Claimed')
+                    ->where('funding_type', $ft->funding_type)
+                    ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
 
-            $ts_hold = Claim::where('institution_guid', $institution->guid)
-                ->where('allocation_guid', $instAllocation->guid)
-                ->where('claim_status', 'Hold')
-                ->whereHas('program', function($q) {
-                    $q->where('funding_type', 'Transferable Skills');
-                })
-                ->sum(\DB::raw('COALESCE(estimated_hold_amount, 0)'));
+                $allocated = (float) $ft->amount;
+                $holdWithAdmin = $withAdmin($hold);
+                $claimedWithAdmin = $withAdmin($claimed);
 
-            $ts_claimed = Claim::where('institution_guid', $institution->guid)
-                ->where('allocation_guid', $instAllocation->guid)
-                ->where('claim_status', 'Claimed')
-                ->whereHas('program', function($q) {
-                    $q->where('funding_type', 'Transferable Skills');
-                })
-                ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
+                return [
+                    'funding_type' => $ft->funding_type,
+                    'allocated' => $allocated,
+                    'hold' => $holdWithAdmin,
+                    'claimed' => $claimedWithAdmin,
+                    'remaining' => $allocated - $holdWithAdmin - $claimedWithAdmin,
+                ];
+            })->values();
 
-            $waiting_outcome = Claim::where('institution_guid', $institution->guid)
-                ->where('allocation_guid', $instAllocation->guid)
-                ->where('claim_status', 'Claimed')
-                ->whereNull('outcome_effective_date') //outcome_effective_date', 'outcome_status are not set
-                ->whereNull('outcome_status')
-                ->count();
-
-            if ($programYear->claim_percent == 0) {
-                return Inertia::render('Institution::Dashboard', [
-                    'results' => $institution,
-                    'activeAllocation' => $instAllocation,
-                    'programYear' => $programYear,
-                    'holdApps' => $gov_hold,
-                    'claimedApps' => $gov_claimed,
-                    'tsHoldAmount' => $ts_hold,
-                    'tsClaimedAmount' => $ts_claimed,
-                ]);
-
+            // Legacy fallback: allocations created before funding types existed have none defined.
+            // For those we show combined hold/claimed only (no funding-type split, no TS cards).
+            $legacyHold = null;
+            $legacyClaimed = null;
+            if ($fundingTypes->isEmpty()) {
+                $legacyHold = $withAdmin(
+                    Claim::where('institution_guid', $institution->guid)
+                        ->where('allocation_guid', $allocation->guid)
+                        ->where('claim_status', 'Hold')
+                        ->sum(\DB::raw('COALESCE(estimated_hold_amount, 0)'))
+                );
+                $legacyClaimed = $withAdmin(
+                    Claim::where('institution_guid', $institution->guid)
+                        ->where('allocation_guid', $allocation->guid)
+                        ->where('claim_status', 'Claimed')
+                        ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'))
+                );
             }
 
-            return Inertia::render('Institution::Dashboard', [
-                'results' => $institution,
-                'activeAllocation' => $instAllocation,
-                'programYear' => $programYear,
-                'holdApps' => $gov_hold ? (float) $gov_hold + ((float) $gov_hold / (float) $programYear->claim_percent) : 0,
-                'claimedApps' => $gov_claimed ? (float) $gov_claimed + ((float) $gov_claimed / (float) $programYear->claim_percent) : 0,
-                'tsHoldAmount' => $ts_hold ? (float) $ts_hold + ((float) $ts_hold / (float) $programYear->claim_percent) : 0,
-                'tsClaimedAmount' => $ts_claimed ? (float) $ts_claimed + ((float) $ts_claimed / (float) $programYear->claim_percent) : 0,
-                'waitingOutcome' => $waiting_outcome,
-            ]);
-        }
+            return [
+                'guid' => $allocation->guid,
+                'total_amount' => (float) $allocation->total_amount,
+                'has_funding_types' => $fundingTypes->isNotEmpty(),
+                'funding_types' => $fundingTypeCards,
+                'legacy_hold' => $legacyHold,
+                'legacy_claimed' => $legacyClaimed,
+            ];
+        })->values();
+
+        // Claims awaiting outcome reporting across all active allocations for the program year.
+        $waitingOutcome = Claim::where('institution_guid', $institution->guid)
+            ->whereIn('allocation_guid', $institution->allocations->pluck('guid'))
+            ->where('claim_status', 'Claimed')
+            ->whereNull('outcome_effective_date')
+            ->whereNull('outcome_status')
+            ->count();
 
         return Inertia::render('Institution::Dashboard', [
             'results' => $institution,
-            'activeAllocation' => $instAllocation,
             'programYear' => $programYear,
-            'holdApps' => 0,
-            'claimedApps' => 0,
-            'tsHoldAmount' => 0,
-            'tsClaimedAmount' => 0,
-            'waitingOutcome' => 0,
+            'allocationSummaries' => $allocationSummaries,
+            'waitingOutcome' => $waitingOutcome,
         ]);
     }
 

--- a/Modules/Institution/resources/assets/js/Components/ClaimEdit.vue
+++ b/Modules/Institution/resources/assets/js/Components/ClaimEdit.vue
@@ -28,8 +28,8 @@
                     </div>
                     <div class="col-md-6">
                         <Label for="inputFundingType" class="form-label" value="Funding Type" />
-                        <span v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</span>
-                        <span v-else> - </span>
+                        <p v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</p>
+                        <p v-else> - </p>
                     </div>
 
                     <div class="col-md-4">

--- a/Modules/Institution/resources/assets/js/Components/ClaimEdit.vue
+++ b/Modules/Institution/resources/assets/js/Components/ClaimEdit.vue
@@ -28,8 +28,9 @@
                     </div>
                     <div class="col-md-6">
                         <Label for="inputFundingType" class="form-label" value="Funding Type" />
-                        <p v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</p>
-                        <p v-else> - </p>
+                        <p>{{ editStudentClaimForm.claim_status === 'Claimed'
+                            ? (editStudentClaimForm.funding_type || 'Gov. Priorities')
+                            : ((programs.find(p => p.guid === editStudentClaimForm.program_guid)?.funding_type) || 'Gov. Priorities') }}</p>
                     </div>
 
                     <div class="col-md-4">

--- a/Modules/Institution/resources/assets/js/Pages/Dashboard.vue
+++ b/Modules/Institution/resources/assets/js/Pages/Dashboard.vue
@@ -19,7 +19,7 @@
                 </div>
             </div>
 
-            <div v-if="activeAllocation == null" class="row">
+            <div v-if="!allocationSummaries || allocationSummaries.length === 0" class="row">
                 <div class="col-12 mb-3">
                     <div class="text-center">
                         You have no active allocations for this program year.
@@ -28,69 +28,54 @@
 
             </div>
             <div v-else>
-                <div class="row">
-                    <div class="col-md-4 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Total Gov Allocation (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(((activeAllocation && activeAllocation.ts_percent !== undefined ? (100 - activeAllocation.ts_percent) : 80) / 100 * (activeAllocation ? activeAllocation.total_amount : 0)).toFixed(2)) }}</div>
-                        </div>
+                <div v-for="alloc in allocationSummaries" :key="alloc.guid" class="card mb-4">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span class="fw-semibold">Total Allocation (includes Admin)</span>
+                        <span class="fw-bold">${{ $formatNumberWithCommas(Number(alloc.total_amount).toFixed(2)) }}</span>
                     </div>
-                    <div class="col-md-4 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Total Transferrable (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(((activeAllocation && activeAllocation.ts_percent !== undefined ? activeAllocation.ts_percent : 20) / 100 * (activeAllocation ? activeAllocation.total_amount : 0)).toFixed(2)) }}</div>
+                    <div class="card-body">
+                        <!-- New per funding type cards -->
+                        <div v-if="alloc.has_funding_types" class="row">
+                            <div v-for="ft in alloc.funding_types" :key="ft.funding_type" class="col-md-4 mb-3">
+                                <div class="card h-100 text-center">
+                                    <div class="card-header fw-semibold">{{ ft.funding_type }}</div>
+                                    <div class="card-body">
+                                        <div class="d-flex justify-content-between"><span>Allocated</span><strong>${{ $formatNumberWithCommas(Number(ft.allocated).toFixed(2)) }}</strong></div>
+                                        <div class="d-flex justify-content-between"><span>Hold</span><strong>${{ $formatNumberWithCommas(Number(ft.hold).toFixed(2)) }}</strong></div>
+                                        <div class="d-flex justify-content-between"><span>Claimed</span><strong>${{ $formatNumberWithCommas(Number(ft.claimed).toFixed(2)) }}</strong></div>
+                                        <hr class="my-2"/>
+                                        <div class="d-flex justify-content-between"><span>Remaining</span><strong>${{ $formatNumberWithCommas(Number(ft.remaining).toFixed(2)) }}</strong></div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="col-md-4 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Total Allocation (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(activeAllocation ? activeAllocation.total_amount : 0) }}</div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Government Hold (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(holdApps) }}</div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Government Claimed (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(claimedApps) }}</div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Transferable Skills Hold (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(tsHoldAmount) }}</div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Transferable Skills Claimed (includes Admin)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas(tsClaimedAmount) }}</div>
+                        <!-- Legacy allocation without funding types -->
+                        <div v-else class="row">
+                            <div class="col-md-6 mb-3">
+                                <div class="card text-center">
+                                    <div class="card-header">Hold (includes Admin)</div>
+                                    <div class="card-body display-6 m-3">${{ $formatNumberWithCommas(Number(alloc.legacy_hold || 0).toFixed(2)) }}</div>
+                                </div>
+                            </div>
+                            <div class="col-md-6 mb-3">
+                                <div class="card text-center">
+                                    <div class="card-header">Claimed (includes Admin)</div>
+                                    <div class="card-body display-6 m-3">${{ $formatNumberWithCommas(Number(alloc.legacy_claimed || 0).toFixed(2)) }}</div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
+
                 <div class="row">
-                    <div class="col-md-6 mb-3">
-                        <div class="card text-center">
-                            <div class="card-header">Committed Amount (Claimed + Hold)</div>
-                            <div class="card-body display-5 m-4">${{ $formatNumberWithCommas((Number(claimedApps) + Number(holdApps) + Number(tsHoldAmount) + Number(tsClaimedAmount)).toFixed(2)) }}</div>
-                        </div>
-                    </div>
-                    <div class="col-md-6 mb-3">
+                    <div class="col-md-12 mb-3">
                         <div class="card text-center">
                             <div class="card-header">Claims Waiting for Outcome Reporting</div>
                             <div class="card-body display-5 m-4">{{ $formatNumberWithCommas((Number(waitingOutcome)).toFixed(2)) }}</div>
                         </div>
                     </div>
                 </div>
-                
+
             </div>
         </div>
 
@@ -112,12 +97,8 @@ export default {
     },
     props: {
         results: Object,
-        activeAllocation: Object,
         programYear: Object,
-        holdApps: Number,
-        claimedApps: Number,
-        tsHoldAmount: Number,
-        tsClaimedAmount: Number,
+        allocationSummaries: Array,
         waitingOutcome: Number
     }
 }

--- a/Modules/Ministry/app/Http/Controllers/AllocationController.php
+++ b/Modules/Ministry/app/Http/Controllers/AllocationController.php
@@ -8,8 +8,10 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\AllocationEditRequest;
 use App\Http\Requests\AllocationStoreRequest;
 use App\Models\Allocation;
+use App\Models\AllocationFundingType;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Str;
 use Response;
 
 class AllocationController extends Controller
@@ -29,7 +31,17 @@ class AllocationController extends Controller
      */
     public function store(AllocationStoreRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $allocation = Allocation::create($request->validated());
+        $allocation = Allocation::create($request->safe()->except('funding_types'));
+
+        foreach ($request->input('funding_types', []) as $fundingType) {
+            AllocationFundingType::create([
+                'guid' => Str::orderedUuid()->getHex(),
+                'allocation_guid' => $allocation->guid,
+                'funding_type' => $fundingType['funding_type'],
+                'amount' => $fundingType['amount'],
+                'last_touch_by_user_guid' => $request->user()->guid,
+            ]);
+        }
 
         event(new AllocationCreated($allocation));
 
@@ -41,8 +53,20 @@ class AllocationController extends Controller
      */
     public function update(AllocationEditRequest $request): \Illuminate\Http\RedirectResponse
     {
-        $allocation_id = Allocation::where('id', $request->id)->update($request->validated());
+        Allocation::where('id', $request->id)->update($request->safe()->except('funding_types'));
         $allocation = Allocation::find($request->id);
+
+        // Sync the allocation funding types: remove the existing ones and recreate from the request.
+        $allocation->fundingTypes()->delete();
+        foreach ($request->input('funding_types', []) as $fundingType) {
+            AllocationFundingType::create([
+                'guid' => Str::orderedUuid()->getHex(),
+                'allocation_guid' => $allocation->guid,
+                'funding_type' => $fundingType['funding_type'],
+                'amount' => $fundingType['amount'],
+                'last_touch_by_user_guid' => $request->user()->guid,
+            ]);
+        }
 
         event(new AllocationUpdated($allocation, $request->status));
 

--- a/Modules/Ministry/app/Http/Controllers/InstitutionController.php
+++ b/Modules/Ministry/app/Http/Controllers/InstitutionController.php
@@ -33,7 +33,7 @@ class InstitutionController extends Controller
     public function show(Institution $institution, $page = 'details')
     {
         $institution = Institution::where('id', $institution->id)->with(
-            ['allocations.py', 'activeAllocation', 'staff.user.roles', 'programs']
+            ['allocations.py', 'allocations.fundingTypes', 'activeAllocation', 'activeAllocation.fundingTypes', 'staff.user.roles', 'programs']
         )->first();
 
         $countries = Cache::remember('countries', 380, function () {

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationCreate.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationCreate.vue
@@ -21,11 +21,34 @@
                     </div>
                 </div>
 
-                <div class="col-md-4">
-                    <Label for="inputTSPercent" class="form-label" value="TS %"/>
-                    <div class="input-group mb-3">
-                        <Input type="number" class="form-control" id="inputTSPercent" min="0" max="100" v-model.number="newInstitutionAllocationForm.ts_percent"/>
-                        <span class="input-group-text">%</span>
+                <div class="col-12">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <Label class="form-label mb-0" value="Funding Types"/>
+                        <button type="button" class="btn btn-sm btn-outline-success" @click="addFundingType">Add Funding Type</button>
+                    </div>
+
+                    <p v-if="newInstitutionAllocationForm.funding_types.length === 0" class="text-muted small mb-0">
+                        No funding types added. Click "Add Funding Type" to add one.
+                    </p>
+
+                    <div v-for="(row, index) in newInstitutionAllocationForm.funding_types" :key="index" class="row g-2 align-items-end mb-2">
+                        <div class="col-md-6">
+                            <Label :for="'inputFundingType' + index" class="form-label" value="Funding Type"/>
+                            <Select class="form-select" :id="'inputFundingType' + index" v-model="row.funding_type">
+                                <option value=""></option>
+                                <option v-for="ft in fundingTypeOptions" :key="ft.field_name" :value="ft.field_name">{{ ft.field_name }}</option>
+                            </Select>
+                        </div>
+                        <div class="col-md-5">
+                            <Label :for="'inputFundingAmount' + index" class="form-label" value="Amount"/>
+                            <div class="input-group">
+                                <span class="input-group-text">$</span>
+                                <Input type="number" class="form-control" :id="'inputFundingAmount' + index" min="0" v-model.number="row.amount"/>
+                            </div>
+                        </div>
+                        <div class="col-md-1">
+                            <button type="button" class="btn btn-sm btn-outline-danger" @click="removeFundingType(index)" aria-label="Remove">&times;</button>
+                        </div>
                     </div>
                 </div>
 
@@ -80,11 +103,25 @@ export default {
                 allocation_guid: "",
                 program_year_guid: "",
                 total_amount: "",
-                ts_percent: 20,
+                funding_types: [],
             },
         }
     },
+    computed: {
+        fundingTypeOptions() {
+            const utils = this.$attrs.utils || {};
+            return utils['Funding Type'] || [];
+        }
+    },
     methods: {
+
+        addFundingType: function () {
+            this.newInstitutionAllocationForm.funding_types.push({ funding_type: "", amount: "" });
+        },
+
+        removeFundingType: function (index) {
+            this.newInstitutionAllocationForm.funding_types.splice(index, 1);
+        },
 
         submitForm: function () {
             // let check = confirm('You are about to create a new Institution Allocation. The new amount will override the previous cap and disable the old active Institution Cap. Are you sure you want to continue?');

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationEdit.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationEdit.vue
@@ -29,11 +29,34 @@
                     </div>
                 </div>
 
-                <div class="col-md-3">
-                    <Label for="inputTSPercent" class="form-label" value="TS %"/>
-                    <div class="input-group mb-3">
-                        <Input type="number" class="form-control" id="inputTSPercent" min="0" max="100" v-model.number="editInstitutionAllocationForm.ts_percent"/>
-                        <span class="input-group-text">%</span>
+                <div class="col-12">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <Label class="form-label mb-0" value="Funding Types"/>
+                        <button type="button" class="btn btn-sm btn-outline-success" @click="addFundingType">Add Funding Type</button>
+                    </div>
+
+                    <p v-if="editInstitutionAllocationForm.funding_types.length === 0" class="text-muted small mb-0">
+                        No funding types added. Click "Add Funding Type" to add one.
+                    </p>
+
+                    <div v-for="(row, index) in editInstitutionAllocationForm.funding_types" :key="index" class="row g-2 align-items-end mb-2">
+                        <div class="col-md-6">
+                            <Label :for="'inputFundingType' + index" class="form-label" value="Funding Type"/>
+                            <Select class="form-select" :id="'inputFundingType' + index" v-model="row.funding_type">
+                                <option value=""></option>
+                                <option v-for="ft in fundingTypeOptions" :key="ft.field_name" :value="ft.field_name">{{ ft.field_name }}</option>
+                            </Select>
+                        </div>
+                        <div class="col-md-5">
+                            <Label :for="'inputFundingAmount' + index" class="form-label" value="Amount"/>
+                            <div class="input-group">
+                                <span class="input-group-text">$</span>
+                                <Input type="number" class="form-control" :id="'inputFundingAmount' + index" min="0" v-model.number="row.amount"/>
+                            </div>
+                        </div>
+                        <div class="col-md-1">
+                            <button type="button" class="btn btn-sm btn-outline-danger" @click="removeFundingType(index)" aria-label="Remove">&times;</button>
+                        </div>
                     </div>
                 </div>
 
@@ -88,14 +111,26 @@ export default {
                 total_amount: "",
                 program_year_guid: "",
                 status: "",
-                ts_percent: ""
+                funding_types: [],
             },
             selectedFedCap: '',
             allowProgramCap: false,
             newAllocation: false
         }
     },
+    computed: {
+        fundingTypeOptions() {
+            const utils = this.$attrs.utils || {};
+            return utils['Funding Type'] || [];
+        }
+    },
     methods: {
+        addFundingType: function () {
+            this.editInstitutionAllocationForm.funding_types.push({ funding_type: "", amount: "" });
+        },
+        removeFundingType: function (index) {
+            this.editInstitutionAllocationForm.funding_types.splice(index, 1);
+        },
         switchStatus: function () {
             if(this.editInstitutionAllocationForm.status === 'active'){
                 this.newAllocation = true;
@@ -130,6 +165,10 @@ export default {
     mounted() {
         this.editInstitutionAllocationFormData = this.allocation;
         this.editInstitutionAllocationFormData.total_amount = this.editInstitutionAllocationFormData.total_amount_formatted;
+        this.editInstitutionAllocationFormData.funding_types = (this.allocation.funding_types || []).map(ft => ({
+            funding_type: ft.funding_type,
+            amount: ft.amount,
+        }));
         this.editInstitutionAllocationForm = useForm(this.editInstitutionAllocationFormData);
     }
 }

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionAllocations.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionAllocations.vue
@@ -22,8 +22,6 @@
                             <td>{{ row.py.end_date }}</td>
                             <td>${{ $formatNumberWithCommas(row.total_amount_formatted) }}</td>
                             <td>${{ $formatNumberWithCommas(row.claimed) }}</td>
-                            <td>${{ $formatNumberWithCommas(((row.ts_percent ?? 20) / 100 * row.total_amount).toFixed(2)) }}</td>
-                            <td>{{ row.ts_percent ?? 20 }}%</td>
                             <td>
                                 <span v-if="row.status === 'new'" class="badge rounded-pill text-bg-info">New</span>
                                 <span v-else-if="row.status === 'active'" class="badge rounded-pill text-bg-success">Active</span>

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationsHeader.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionAllocationsHeader.vue
@@ -12,12 +12,6 @@
         <th scope="col" style="min-width: 80px;">
             <span>Used Allocation</span>
         </th>
-        <th scope="col" style="min-width: 100px;">
-            <span>TS Allocation</span>
-        </th>
-        <th scope="col" style="min-width: 100px;">
-            <span>TS %</span>
-        </th>
         <th scope="col">
             <span>Status</span>
         </th>

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionProgramCreate.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionProgramCreate.vue
@@ -34,7 +34,7 @@
                 <div class="col-md-3">
                     <Label for="inputFundingType" class="form-label" value="Funding Type"/>
                     <Select class="form-select" id="inputFundingType" v-model="editForm.funding_type">
-                        <option v-for="stat in $attrs.utils['Funding Type']" :value="stat.field_name">{{ stat.field_name }}</option>
+                        <option v-for="stat in fundingTypeOptions" :value="stat.field_name">{{ stat.field_name }}</option>
                     </Select>
                 </div>
 
@@ -155,6 +155,14 @@ export default {
                 end_date: "",
                 funding_type: '',
             },
+        }
+    },
+    computed: {
+        fundingTypeOptions() {
+            const all = (this.$attrs.utils && this.$attrs.utils['Funding Type']) || [];
+            const active = (this.results && this.results.active_allocation && this.results.active_allocation.funding_types) || [];
+            const allowed = active.map(ft => ft.funding_type);
+            return all.filter(ft => allowed.includes(ft.field_name));
         }
     },
     methods: {

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionProgramEdit.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionProgramEdit.vue
@@ -32,7 +32,7 @@
                 <div class="col-md-3">
                     <Label for="inputFundingType" class="form-label" value="Funding Type"/>
                     <Select class="form-select" id="inputFundingType" v-model="editForm.funding_type">
-                        <option v-for="stat in $attrs.utils['Funding Type']" :value="stat.field_name">{{ stat.field_name }}</option>
+                        <option v-for="stat in fundingTypeOptions" :value="stat.field_name">{{ stat.field_name }}</option>
                     </Select>
                 </div>
 
@@ -139,6 +139,20 @@ export default {
                 formFailMsg: 'There was an error submitting this form.',
                 funding_type: '',
             },
+        }
+    },
+    computed: {
+        fundingTypeOptions() {
+            const all = (this.$attrs.utils && this.$attrs.utils['Funding Type']) || [];
+            const active = (this.results && this.results.active_allocation && this.results.active_allocation.funding_types) || [];
+            const allowed = active.map(ft => ft.funding_type);
+            let options = all.filter(ft => allowed.includes(ft.field_name));
+            // Keep the currently selected funding type visible even if it is no longer in the active allocation.
+            const current = this.editForm ? this.editForm.funding_type : '';
+            if (current && !options.some(ft => ft.field_name === current)) {
+                options = [...options, { field_name: current }];
+            }
+            return options;
         }
     },
     methods: {

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionPrograms.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionPrograms.vue
@@ -15,6 +15,7 @@
                             <td><a href="#" @click="openEditForm(row)">{{ row.program_name }}</a></td>
                             <td>{{ row.delivery_method }}</td>
                             <td>{{ row.credential_type }}</td>
+                            <td>{{ row.funding_type }}</td>
                             <td>
                                 <span v-if="row.active_status" class="badge rounded-pill text-bg-success">Active</span>
                                 <span v-else class="badge rounded-pill text-bg-danger">Inactive</span>

--- a/Modules/Ministry/resources/assets/js/Components/InstitutionProgramsHeader.vue
+++ b/Modules/Ministry/resources/assets/js/Components/InstitutionProgramsHeader.vue
@@ -10,6 +10,9 @@
             <span>Credential Type</span>
         </th>
         <th scope="col">
+            <span>Funding Type</span>
+        </th>
+        <th scope="col">
             <span>Status</span>
         </th>
     </tr>

--- a/Modules/Ministry/resources/assets/js/Components/StudentClaimEdit.vue
+++ b/Modules/Ministry/resources/assets/js/Components/StudentClaimEdit.vue
@@ -13,8 +13,8 @@
                 </div>
                 <div class="col-md-3">
                     <Label for="inputFundingType" class="form-label" value="Funding Type" />
-                    <span v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</span>
-                    <span v-else> - </span>
+                    <p v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</p>
+                    <p v-else> - </p>
                 </div>
 
                 <div class="col-md-3">

--- a/Modules/Ministry/resources/assets/js/Components/StudentClaimEdit.vue
+++ b/Modules/Ministry/resources/assets/js/Components/StudentClaimEdit.vue
@@ -13,8 +13,9 @@
                 </div>
                 <div class="col-md-3">
                     <Label for="inputFundingType" class="form-label" value="Funding Type" />
-                    <p v-if="editStudentClaimForm.program !== null">{{ editStudentClaimForm.program.funding_type }}</p>
-                    <p v-else> - </p>
+                    <p>{{ editStudentClaimForm.claim_status === 'Claimed'
+                        ? (editStudentClaimForm.funding_type || 'Gov. Priorities')
+                        : ((programs.find(p => p.guid === editStudentClaimForm.program_guid)?.funding_type) || 'Gov. Priorities') }}</p>
                 </div>
 
                 <div class="col-md-3">

--- a/app/Http/Requests/AllocationEditRequest.php
+++ b/app/Http/Requests/AllocationEditRequest.php
@@ -34,6 +34,10 @@ class AllocationEditRequest extends FormRequest
     public function messages()
     {
         return [
+            'funding_types.*.funding_type.required' => 'The Funding Type field is required.',
+            'funding_types.*.funding_type.exists' => 'The selected Funding Type is invalid.',
+            'funding_types.*.amount.required' => 'The Funding Type amount is required.',
+            'funding_types.*.amount.lte' => 'The Funding Type amount cannot be higher than the Total Allowed.',
         ];
     }
 
@@ -51,7 +55,9 @@ class AllocationEditRequest extends FormRequest
             'program_year_guid' => 'required|exists:program_years,guid',
             'total_amount' => 'required|numeric',
             'status' => 'required',
-            'ts_percent' => 'required|numeric|min:0|max:100',
+            'funding_types' => 'nullable|array',
+            'funding_types.*.funding_type' => 'required|string|exists:utils,field_name',
+            'funding_types.*.amount' => 'required|numeric|min:0|lte:total_amount',
         ];
     }
 

--- a/app/Http/Requests/AllocationStoreRequest.php
+++ b/app/Http/Requests/AllocationStoreRequest.php
@@ -26,6 +26,10 @@ class AllocationStoreRequest extends FormRequest
         return [
             'institution_guid.required' => 'The Institution field is required.',
             'program_year_guid.required' => 'The Program Year field is required.',
+            'funding_types.*.funding_type.required' => 'The Funding Type field is required.',
+            'funding_types.*.funding_type.exists' => 'The selected Funding Type is invalid.',
+            'funding_types.*.amount.required' => 'The Funding Type amount is required.',
+            'funding_types.*.amount.lte' => 'The Funding Type amount cannot be higher than the Total Allowed.',
             'required' => 'The :attribute field is required.',
         ];
     }
@@ -43,7 +47,9 @@ class AllocationStoreRequest extends FormRequest
             'program_year_guid' => 'required|exists:program_years,guid',
             'total_amount' => 'required|numeric',
             'status' => 'required',
-            'ts_percent' => 'required|numeric|min:0|max:100',
+            'funding_types' => 'nullable|array',
+            'funding_types.*.funding_type' => 'required|string|exists:utils,field_name',
+            'funding_types.*.amount' => 'required|numeric|min:0|lte:total_amount',
         ];
     }
 

--- a/app/Listeners/ProcessMinistrySubmittedClaim.php
+++ b/app/Listeners/ProcessMinistrySubmittedClaim.php
@@ -4,6 +4,7 @@ namespace App\Listeners;
 
 use App\Events\ClaimSubmitted;
 use App\Events\MinistryClaimSubmitted;
+use App\Models\AllocationFundingType;
 use App\Models\Claim;
 use App\Models\Program;
 use App\Models\Student;
@@ -155,33 +156,37 @@ class ProcessMinistrySubmittedClaim
                     $claim->correction_amount = 0;
                 }
 
-                // if the program of the claim is of type Transferable Skills, then we need to check the ts_percent
-                if ($program->funding_type === 'Transferable Skills') {
-                    // Calculate sum claims of the institution that are not Draft, Cancelled or Expired
-                    // We need the sum of claims that are Claimed and claim.program are of type Transferable Skills
-                    $sum_ts_claims = Claim::
-                        where('claim_status', 'Claimed')
-                            ->where('institution_guid', $claim->institution_guid)
-                            ->where('allocation_guid', $claim->allocation_guid)
-                            ->whereHas('program', function($q) {
-                                $q->where('funding_type', 'Transferable Skills');
-                            })
-                            ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
+                // Enforce the per-funding-type dollar cap defined on the allocation.
+                // Replaces the legacy ts_percent check: each allocation can now define one or many
+                // funding types, each with its own maximum dollar amount.
+                if (!empty($claim->funding_type)) {
+                    $fundingTypeAllocation = AllocationFundingType::where('allocation_guid', $claim->allocation_guid)
+                        ->where('funding_type', $claim->funding_type)
+                        ->first();
 
-                    $ts_claims_total = (float) $sum_ts_claims + ((float) $sum_ts_claims / (float) $claim->py_admin_fee);
+                    // Only enforce a cap when the allocation explicitly defines one for this funding type.
+                    if ($fundingTypeAllocation) {
+                        // Sum the Claimed claims of the institution for the same allocation and funding
+                        // type (the current claim is already saved as Claimed), then add the admin fee.
+                        $sum_ft_claims = Claim::
+                            where('claim_status', 'Claimed')
+                                ->where('institution_guid', $claim->institution_guid)
+                                ->where('allocation_guid', $claim->allocation_guid)
+                                ->where('funding_type', $claim->funding_type)
+                                ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
 
-                    // Check if the total of the claim is greater than the ts_percent of the allocation
-                    $tsPercent = (float) $claim->allocation->ts_percent;
+                        $ft_claims_total = (float) $sum_ft_claims + ((float) $sum_ft_claims / (float) $claim->py_admin_fee);
 
-                    // If the total claim amount is greater than the ts_percent, then we need to set it to Hold
-                    if ($ts_claims_total > ((float) $claim->allocation->total_amount * ($tsPercent / 100))) {
-                        $claim->process_feedback = 'Claim exceeds the Transferable Skills percentage limit';
-                        $claim->claim_status = 'Hold';
-                        $claim->total_claim_amount = 0;
-                        $claim->program_fee = 0;
-                        $claim->materials_fee = 0;
-                        $claim->registration_fee = 0;
-                        $claim->correction_amount = 0;
+                        // If the funding type total exceeds its allocated dollar amount, set it to Hold
+                        if ($ft_claims_total > (float) $fundingTypeAllocation->amount) {
+                            $claim->process_feedback = 'Claim exceeds the "'.$claim->funding_type.'" funding type allocation limit';
+                            $claim->claim_status = 'Hold';
+                            $claim->total_claim_amount = 0;
+                            $claim->program_fee = 0;
+                            $claim->materials_fee = 0;
+                            $claim->registration_fee = 0;
+                            $claim->correction_amount = 0;
+                        }
                     }
                 }
                 //check student

--- a/app/Listeners/ProcessSubmittedClaim.php
+++ b/app/Listeners/ProcessSubmittedClaim.php
@@ -3,6 +3,7 @@
 namespace App\Listeners;
 
 use App\Events\ClaimSubmitted;
+use App\Models\AllocationFundingType;
 use App\Models\Claim;
 use App\Models\Program;
 use App\Models\Student;
@@ -164,39 +165,42 @@ class ProcessSubmittedClaim
                     $checkStatus = false;
                 }
 
-                // if the program of the claim is of type Transferable Skills, then we need to check the ts_percent
-                if ($checkStatus && $program->funding_type === 'Transferable Skills') {
-                    Log::info('claim is of type Transferable Skills');
-                    // Calculate sum claims of the institution that are not Draft, Cancelled or Expired
-                    // We need the sum of claims that are Claimed and claim.program are of type Transferable Skills
-                    // exclude the current claim
-                    $sum_ts_claims = Claim::where('claim_status', 'Claimed')
-                            ->where('institution_guid', $claim->institution_guid)
-                            ->where('allocation_guid', $claim->allocation_guid)
-                            ->where('id', '!=', $claim->id)
-                            ->whereHas('program', function($q) {
-                                $q->where('funding_type', 'Transferable Skills');
-                            })
-                            ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
+                // Enforce the per-funding-type dollar cap defined on the allocation.
+                // Replaces the legacy ts_percent check: each allocation can now define one or many
+                // funding types, each with its own maximum dollar amount.
+                if ($checkStatus && !empty($claim->funding_type)) {
+                    $fundingTypeAllocation = AllocationFundingType::where('allocation_guid', $claim->allocation_guid)
+                        ->where('funding_type', $claim->funding_type)
+                        ->first();
 
-                    $ts_claims_total = (float) $sum_ts_claims + ((float) $sum_ts_claims / (float) $claim->py_admin_fee);
+                    // Only enforce a cap when the allocation explicitly defines one for this funding type.
+                    if ($fundingTypeAllocation) {
+                        Log::info('checking funding type "'.$claim->funding_type.'" allocation limit');
+                        // Sum the Claimed claims of the institution for the same allocation and funding
+                        // type (the current claim is already saved as Claimed), then add the admin fee
+                        // so the comparison matches the allocation accounting.
+                        $sum_ft_claims = Claim::where('claim_status', 'Claimed')
+                                ->where('institution_guid', $claim->institution_guid)
+                                ->where('allocation_guid', $claim->allocation_guid)
+                                ->where('funding_type', $claim->funding_type)
+                                ->sum(\DB::raw('COALESCE(program_fee, 0) + COALESCE(materials_fee, 0) + COALESCE(registration_fee, 0) + COALESCE(correction_amount, 0)'));
 
-                    // Check if the total of the claim is greater than the ts_percent of the allocation
-                    $tsPercent = (float) $claim->allocation->ts_percent;
-                    Log::info('ts_claims_total = '.number_format($ts_claims_total, 0));
+                        $ft_claims_total = (float) $sum_ft_claims + ((float) $sum_ft_claims / (float) $claim->py_admin_fee);
+                        Log::info('funding type claims total = '.number_format($ft_claims_total, 0));
 
-                    // If the total claim amount is greater than the ts_percent, then we need to set it to Hold
-                    if ($ts_claims_total > ((float) $claim->allocation->total_amount * ($tsPercent / 100))) {
+                        // If the funding type total exceeds its allocated dollar amount, set it to Hold
+                        if ($ft_claims_total > (float) $fundingTypeAllocation->amount) {
 
-                        Log::info('ts_claims_total = '.number_format($ts_claims_total, 0) . ' > allocation total_amount * ts_percent = '.number_format((float) $claim->allocation->total_amount * ($tsPercent / 100), 0));
-                        $claim->process_feedback = 'Claim exceeds the Transferable Skills percentage limit.';
-                        $claim->claim_status = 'Hold';
-                        $claim->total_claim_amount = 0;
-                        $claim->program_fee = 0;
-                        $claim->materials_fee = 0;
-                        $claim->registration_fee = 0;
-                        $claim->correction_amount = 0;
-                        $checkStatus = false;
+                            Log::info('funding type total = '.number_format($ft_claims_total, 0) . ' > funding type allocation = '.number_format((float) $fundingTypeAllocation->amount, 0));
+                            $claim->process_feedback = 'Claim exceeds the "'.$claim->funding_type.'" funding type allocation limit.';
+                            $claim->claim_status = 'Hold';
+                            $claim->total_claim_amount = 0;
+                            $claim->program_fee = 0;
+                            $claim->materials_fee = 0;
+                            $claim->registration_fee = 0;
+                            $claim->correction_amount = 0;
+                            $checkStatus = false;
+                        }
                     }
                 }
 

--- a/app/Models/Allocation.php
+++ b/app/Models/Allocation.php
@@ -43,6 +43,11 @@ class Allocation extends Model
         return $this->hasMany(Claim::class, 'allocation_guid', 'guid')->orderByDesc('created_at');
     }
 
+    public function fundingTypes()
+    {
+        return $this->hasMany(AllocationFundingType::class, 'allocation_guid', 'guid');
+    }
+
     // Define the accessor for the computed attribute
     public function getClaimedAttribute()
     {

--- a/app/Models/AllocationFundingType.php
+++ b/app/Models/AllocationFundingType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class AllocationFundingType extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['guid', 'allocation_guid', 'funding_type', 'amount', 'last_touch_by_user_guid'];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = ['last_touch_by_user_guid'];
+
+    public function allocation()
+    {
+        return $this->belongsTo(Allocation::class, 'allocation_guid', 'guid');
+    }
+}

--- a/app/Models/Claim.php
+++ b/app/Models/Claim.php
@@ -26,11 +26,28 @@ class Claim extends Model
         'stable_enrolment_date', 'expiry_date', 'psi_claim_request_date', 'reporting_completed_date',
         'fifty_two_week_affirmation', 'agreement_confirmed', 'registration_confirmed',
         'guid', 'institution_guid', 'allocation_guid', 'program_guid', 'student_guid', 'expected_stable_enrolment_date',
-        'expected_completion_date', 'outcome_effective_date', 'outcome_status', 'correction_amount', 'correction_comment',];
+        'expected_completion_date', 'outcome_effective_date', 'outcome_status', 'correction_amount', 'correction_comment',
+        'funding_type',];
 
     protected static function boot()
     {
         parent::boot();
+
+        static::saving(function ($claim) {
+            // Snapshot the funding type from the program so each claim keeps its own copy.
+            // Once a claim is Claimed the value is frozen, making historical claims immutable
+            // even if the program's funding type is later changed.
+            if (empty($claim->program_guid)) {
+                return;
+            }
+            $isClaimed = $claim->claim_status === 'Claimed';
+            if (!$isClaimed || empty($claim->funding_type)) {
+                $program = Program::where('guid', $claim->program_guid)->first();
+                $claim->funding_type = ($program && $program->funding_type)
+                    ? $program->funding_type
+                    : 'Gov. Priorities';
+            }
+        });
 
         static::updated(function ($claim) {
             $changes = $claim->getChanges();

--- a/database/migrations/2026_06_22_000001_change_ts_percent_default_on_allocations_table.php
+++ b/database/migrations/2026_06_22_000001_change_ts_percent_default_on_allocations_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $columnExists = Schema::hasColumn('allocations', 'ts_percent');
+
+        Schema::table('allocations', function (Blueprint $table) use ($columnExists) {
+            $column = $table->float('ts_percent', 4, 2)->default(0)
+                ->comment('DEPRECATED: Transferable Skills Percent. Replaced by allocation_funding_types. Default changed from 20 to 0.');
+
+            if ($columnExists) {
+                $column->change();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('allocations', 'ts_percent')) {
+            return;
+        }
+
+        Schema::table('allocations', function (Blueprint $table) {
+            $table->float('ts_percent', 4, 2)->default(20)
+                ->comment('Transferable Skills Percent, default is 20%')
+                ->change();
+        });
+    }
+};

--- a/database/migrations/2026_06_22_000002_create_allocation_funding_types_table.php
+++ b/database/migrations/2026_06_22_000002_create_allocation_funding_types_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('allocation_funding_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('guid', 32)->index()->unique();
+
+            $table->string('allocation_guid', 32)->index();
+            $table->foreign('allocation_guid')->references('guid')->on('allocations')
+                ->onDelete('cascade');
+
+            $table->string('funding_type')->index()->comment('Funding Type name from utils');
+            $table->float('amount', 2)->default(0)->comment('Portion of the allocation allowed for this funding type');
+
+            $table->string('last_touch_by_user_guid', 32)->nullable();
+
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('allocation_funding_types');
+    }
+};

--- a/database/migrations/2026_06_23_000001_add_funding_type_to_claims_table.php
+++ b/database/migrations/2026_06_23_000001_add_funding_type_to_claims_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasColumn('claims', 'funding_type')) {
+            Schema::table('claims', function (Blueprint $table) {
+                $table->string('funding_type')->nullable()
+                    ->comment('Snapshot of the program funding type at claim time. Frozen once the claim is Claimed.')
+                    ->after('program_guid');
+            });
+        }
+
+        // Backfill existing claims with their program's current funding type.
+        // Correlated sub-query update is supported by both PostgreSQL (prod) and SQLite (tests).
+        DB::statement(
+            "UPDATE claims SET funding_type = COALESCE("
+            ."(SELECT funding_type FROM programs WHERE programs.guid = claims.program_guid), 'Gov. Priorities') "
+            ."WHERE funding_type IS NULL"
+        );
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('claims', 'funding_type')) {
+            Schema::table('claims', function (Blueprint $table) {
+                $table->dropColumn('funding_type');
+            });
+        }
+    }
+};


### PR DESCRIPTION
This pull request introduces significant improvements to how allocation and funding type data are managed and displayed in the institution dashboard. The main changes include support for multiple funding types per allocation, improved calculation and display of allocation summaries, and updates to both the backend and frontend to support these features.

**Backend Enhancements:**

* Added support for storing and updating multiple funding types per allocation, including syncing funding types on allocation update. [[1]](diffhunk://#diff-3e677845fc96202779165e40f30e4b42bdd50f9740041874cdfb275e5bf7d84dL32-R44) [[2]](diffhunk://#diff-3e677845fc96202779165e40f30e4b42bdd50f9740041874cdfb275e5bf7d84dL44-R70)
* The `InstitutionController@index` method now generates per-allocation, per-funding-type summaries for the dashboard, including legacy support for allocations without funding types.
* Updated data export to prefer the claim's `funding_type` if set, otherwise fallback to the program's `funding_type`.
* Ensured funding types are eager-loaded with allocations in the ministry institution view for efficiency.

**Frontend Updates:**

* The dashboard now displays a summary card for each allocation, with detailed breakdowns by funding type where available, and a legacy view for older allocations. Old summary cards have been removed. [[1]](diffhunk://#diff-abdd3a5790e61e787803bc2fdd5f6e0b6469e0322708728329d8ffdce6e31d73L31-R71) [[2]](diffhunk://#diff-abdd3a5790e61e787803bc2fdd5f6e0b6469e0322708728329d8ffdce6e31d73L115-R101)
* The claim edit form now displays the correct funding type, prioritizing the claim's value or falling back to the program's value as appropriate.
* Improved messaging when there are no active allocations for the program year.

---

### Backend: Allocation and Funding Type Management

* Added creation and update logic for multiple funding types per allocation in `AllocationController`, including syncing funding types on update. [[1]](diffhunk://#diff-3e677845fc96202779165e40f30e4b42bdd50f9740041874cdfb275e5bf7d84dL32-R44) [[2]](diffhunk://#diff-3e677845fc96202779165e40f30e4b42bdd50f9740041874cdfb275e5bf7d84dL44-R70)
* The `InstitutionController@index` method now builds per-allocation, per-funding-type dashboard summaries, with legacy support for allocations lacking funding types.
* Updated CSV export to use the claim's `funding_type` if present, otherwise fallback to the program's `funding_type`.
* Ministry institution views now eager-load funding types for allocations to improve performance.

### Frontend: Dashboard and Claim View Improvements

* Dashboard displays allocation summaries with per-funding-type breakdowns, including allocated, hold, claimed, and remaining amounts; legacy cards shown if no funding types exist. Old summary cards and props removed. [[1]](diffhunk://#diff-abdd3a5790e61e787803bc2fdd5f6e0b6469e0322708728329d8ffdce6e31d73L31-R71) [[2]](diffhunk://#diff-abdd3a5790e61e787803bc2fdd5f6e0b6469e0322708728329d8ffdce6e31d73L115-R101)
* Claim edit form now accurately displays funding type, prioritizing the claim's value or falling back to the program's value.
* Improved UI messaging for cases with no active allocations.