### PR TITLE
Migrate web and backup deployment from DC to Deployment

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -122,7 +122,8 @@ deploy-web:
 	test -n "$(BUILD_NAMESPACE)"
 	@echo "+\n++ Deploying Web into $(NAMESPACE)\n+"
 	@oc -n $(NAMESPACE) process -f $(DEPLOY_FILE) --param-file=$(PARAM_FILE) | oc -n $(NAMESPACE) apply -f -
-	$(call rollout_and_wait,dc/$(HOST_PREFIX))
+	@oc -n $(NAMESPACE) rollout restart deployment/$(HOST_PREFIX)
+	$(call rollout_and_wait,deployment/$(HOST_PREFIX))
 	@echo "+\n++ FINISHED Deploying Web\n+"
 
 build-patroni:

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -148,7 +148,7 @@ db-backup-deploy-postgresql:
 	test -n "$(NAMESPACE)"
 	test -n "$(BUILD_NAMESPACE)"
 	test -n "$(BACKUP_POSTGRESQL_APP_NAME)"
-	@echo "+\n++ Creating deploy config resoures for database backups on $(NAMESPACE)\n+"
+	@echo "+\n++ Creating deployment config resources for database backups on $(NAMESPACE)\n+"
 	oc -n $(NAMESPACE) process -f backup-deploy.yaml \
   	-p BACKUP_POSTGRESQL_APP_NAME=$(BACKUP_POSTGRESQL_APP_NAME) \
   	-p IMAGE_NAMESPACE=$(BUILD_NAMESPACE) \
@@ -167,3 +167,5 @@ db-backup-deploy-postgresql:
 		-p DATABASE_SECRET_PASSWORD_KEY_NAME=superuser-password \
   	-p ENVIRONMENT_FRIENDLY_NAME='$(NAMESPACE) POSTGRESQL DB Backups' \
 		| oc -n $(NAMESPACE) apply -f -
+	@oc -n $(NAMESPACE) rollout restart deployment/$(BACKUP_POSTGRESQL_APP_NAME)
+	$(call rollout_and_wait,deployment/$(BACKUP_POSTGRESQL_APP_NAME))

--- a/openshift/backup-deploy.yaml
+++ b/openshift/backup-deploy.yaml
@@ -94,8 +94,8 @@ objects:
       ftp-password: ${FTP_PASSWORD}
       ftp-url-host: ${FTP_URL_HOST}
 
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${BACKUP_POSTGRESQL_APP_NAME}
       labels:
@@ -107,20 +107,10 @@ objects:
     spec:
       strategy:
         type: Recreate
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${BACKUP_POSTGRESQL_APP_NAME}
-            from:
-              kind: ImageStreamTag
-              namespace: ${IMAGE_NAMESPACE}
-              name: ${SOURCE_IMAGE_NAME}:${TAG_NAME}
       replicas: 1
       selector:
-        name: ${BACKUP_POSTGRESQL_APP_NAME}
+        matchLabels:
+          name: ${BACKUP_POSTGRESQL_APP_NAME}
       template:
         metadata:
           name: ${BACKUP_POSTGRESQL_APP_NAME}
@@ -145,7 +135,9 @@ objects:
                     path: ${CONFIG_FILE_NAME}
           containers:
             - name: ${BACKUP_POSTGRESQL_APP_NAME}
-              image: ""
+              image: >-
+                image-registry.openshift-image-registry.svc:5000/${IMAGE_NAMESPACE}/${SOURCE_IMAGE_NAME}:${TAG_NAME}
+              imagePullPolicy: Always
               ports: []
               env:
                 - name: BACKUP_STRATEGY

--- a/openshift/dc_latest.yaml
+++ b/openshift/dc_latest.yaml
@@ -14,42 +14,32 @@ objects:
           protocol: TCP
           targetPort: 8443
       selector:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       sessionAffinity: None
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+        deployment: ${NAME}
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
         app.kubernetes.io/part-of: ${LABEL_NAME}
 
     spec:
-      triggers:
-        - type: "ConfigChange"
-        - type: "ImageChange"
-          imageChangeParams:
-            automatic: true
-            from:
-              kind: "ImageStreamTag"
-              name: ${NAME}:${IMAGE_TAG}
-              namespace: ${BUILD_NAMESPACE}
-            containerNames:
-              - ${NAME}
       replicas: ${{MIN_REPLICAS}}
       revisionHistoryLimit: 5
       selector:
-        deploymentconfig: ${NAME}
+        matchLabels:
+          deployment: ${NAME}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
-            deploymentconfig: ${NAME}
+            deployment: ${NAME}
             deploy-branch: ${REPO_BRANCH}
           annotations:
             vault.hashicorp.com/agent-inject: 'true'
@@ -72,7 +62,7 @@ objects:
                 name: subpath-env
           containers:
             - image: >-
-                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}
+                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}:${IMAGE_TAG}
               volumeMounts:
                 - name: site-data-volume
                   mountPath: /var/site_data
@@ -159,7 +149,7 @@ objects:
 
                       echo "==========> Starting schedule run"
 
-                      oc -n ${NAMESPACE} get pods -l deploymentconfig=${NAME} -o name | xargs -I {} sh -c 'oc exec -it {} -- php artisan job:dispatch-midnight && oc exec -it {} -- php artisan queue:work --once --queue=midnight'
+                      oc -n ${NAMESPACE} get pods -l deployment=${NAME} -o name | xargs -I {} sh -c 'oc exec -it {} -- php artisan job:dispatch-midnight && oc exec -it {} -- php artisan queue:work --once --queue=midnight'
 
                       echo "==========> Finished schedule run"
 
@@ -184,30 +174,30 @@ objects:
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
   - apiVersion: autoscaling.k8s.io/v1
     kind: VerticalPodAutoscaler
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
     spec:
       targetRef:
-        kind: DeploymentConfig
+        kind: Deployment
         name: ${NAME}
-        apiVersion: apps.openshift.io/v1
+        apiVersion: apps/v1
       updatePolicy:
         updateMode: "Off"
   - apiVersion: autoscaling/v1
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       name: ${NAME}
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        apiVersion: apps/v1
+        kind: Deployment
         name: ${NAME}
       minReplicas: ${{MIN_REPLICAS}}
       maxReplicas: ${{MAX_REPLICAS}}
@@ -223,20 +213,20 @@ objects:
     kind: NetworkPolicy
     metadata:
       name: ${NAME}-allow-external
-      spec:
-        podSelector:
-          matchLabels:
-            deploymentconfig: ${NAME}
-        ingress:
-          - ports:
-            - protocol: TCP
-              port: 8080
-            - protocol: TCP
-              port: 80
-            - protocol: TCP
-              port: 443
-        policyTypes:
-          - Ingress
+    spec:
+      podSelector:
+        matchLabels:
+          deployment: ${NAME}
+      ingress:
+        - ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 80
+          - protocol: TCP
+            port: 443
+      policyTypes:
+        - Ingress
 parameters:
   - name: OC_USER_ID
     required: false

--- a/openshift/dev_dc_latest.yaml
+++ b/openshift/dev_dc_latest.yaml
@@ -14,41 +14,31 @@ objects:
           protocol: TCP
           targetPort: 8443
       selector:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       sessionAffinity: None
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
-  - apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+        deployment: ${NAME}
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
         app.kubernetes.io/part-of: ${LABEL_NAME}
     spec:
-      triggers:
-        - type: "ConfigChange"
-        - type: "ImageChange"
-          imageChangeParams:
-            automatic: true
-            from:
-              kind: "ImageStreamTag"
-              name: ${NAME}:${IMAGE_TAG}
-              namespace: ${BUILD_NAMESPACE}
-            containerNames:
-              - ${NAME}
       replicas: ${{MIN_REPLICAS}}
       revisionHistoryLimit: 5
       selector:
-        deploymentconfig: ${NAME}
+        matchLabels:
+          deployment: ${NAME}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
-            deploymentconfig: ${NAME}
+            deployment: ${NAME}
             deploy-branch: ${REPO_BRANCH}
           annotations:
             vault.hashicorp.com/agent-inject: 'true'
@@ -71,7 +61,7 @@ objects:
                 name: subpath-env
           containers:
             - image: >-
-                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}
+                image-registry.openshift-image-registry.svc:5000/${BUILD_NAMESPACE}/${NAME}:${IMAGE_TAG}
               volumeMounts:
                 - name: site-data-volume
                   mountPath: /var/site_data
@@ -157,7 +147,7 @@ objects:
 
                       echo "==========> Starting schedule run"
 
-                      oc -n ${NAMESPACE} get pods -l deploymentconfig=${NAME} -o name | xargs -I {} sh -c 'oc exec -it {} -- php artisan job:dispatch-midnight && oc exec -it {} -- php artisan queue:work --once --queue=midnight'
+                      oc -n ${NAMESPACE} get pods -l deployment=${NAME} -o name | xargs -I {} sh -c 'oc exec -it {} -- php artisan job:dispatch-midnight && oc exec -it {} -- php artisan queue:work --once --queue=midnight'
 
                       echo "==========> Finished schedule run"
 
@@ -182,7 +172,7 @@ objects:
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       annotations:
         haproxy.router.openshift.io/ip_whitelist: 142.22.0.0/12 142.32.0.0/12 142.35.0.0/12
   - apiVersion: autoscaling.k8s.io/v1
@@ -190,24 +180,24 @@ objects:
     metadata:
       name: ${NAME}
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
     spec:
       targetRef:
-        kind: DeploymentConfig
+        kind: Deployment
         name: ${NAME}
-        apiVersion: apps.openshift.io/v1
+        apiVersion: apps/v1
       updatePolicy:
         updateMode: "Off"
   - apiVersion: autoscaling/v1
     kind: HorizontalPodAutoscaler
     metadata:
       labels:
-        deploymentconfig: ${NAME}
+        deployment: ${NAME}
       name: ${NAME}
     spec:
       scaleTargetRef:
-        apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        apiVersion: apps/v1
+        kind: Deployment
         name: ${NAME}
       minReplicas: ${{MIN_REPLICAS}}
       maxReplicas: ${{MAX_REPLICAS}}
@@ -223,20 +213,20 @@ objects:
     kind: NetworkPolicy
     metadata:
       name: ${NAME}-allow-external
-      spec:
-        podSelector:
-          matchLabels:
-            deploymentconfig: ${NAME}
-        ingress:
-          - ports:
-            - protocol: TCP
-              port: 8080
-            - protocol: TCP
-              port: 80
-            - protocol: TCP
-              port: 443
-        policyTypes:
-          - Ingress
+    spec:
+      podSelector:
+        matchLabels:
+          deployment: ${NAME}
+      ingress:
+        - ports:
+          - protocol: TCP
+            port: 8080
+          - protocol: TCP
+            port: 80
+          - protocol: TCP
+            port: 443
+      policyTypes:
+        - Ingress
 parameters:
   - name: OC_USER_ID
     required: false


### PR DESCRIPTION
#### Changes:

- Updated the configuration in 
    - `dc_latest.yaml` for test and prod
    - `dev_dc_latest.yaml` for dev 
    - `backup-deploy.yaml`
    -  `Makefile` 

   to use the Deployment configuration
- Removed the DC ImageChange trigger and replaced it with `rollout restart` during deployment
- Updated the NetworkPolicy spec hierarchy
