### PR TITLE
hotfix for missing given names

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -427,7 +427,8 @@ class UserController extends Controller
         if ($type === Role::Student) {
             if (! isset($decodedToken['payload']['name'])){
                 \Log::info('No name found in payload for Student.');
-                $decodedToken['payload']['name'] = $decodedToken['payload']['given_names'] . ' ' . $decodedToken['payload']['family_name'];
+                // if $decodedToken['payload']['given_names'] is present use it or else only use $decodedToken['payload']['family_name']
+                $decodedToken['payload']['name'] = isset($decodedToken['payload']['given_names']) ? $decodedToken['payload']['given_names'] . ' ' . $decodedToken['payload']['family_name'] : $decodedToken['payload']['family_name'];
             }
         }
         if ($type === Role::Ministry_GUEST) {


### PR DESCRIPTION
This pull request makes a small adjustment to the way the user's name is constructed for students during the login process. Now, if the `given_names` field is missing from the payload, only the `family_name` will be used for the `name` value instead of resulting in an error or an incomplete name.

- Improved name assignment logic in `pdexLogin` to handle cases where `given_names` is missing by defaulting to `family_name` only.