### PR TITLE
Test

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -427,7 +427,8 @@ class UserController extends Controller
         if ($type === Role::Student) {
             if (! isset($decodedToken['payload']['name'])){
                 \Log::info('No name found in payload for Student.');
-                $decodedToken['payload']['name'] = $decodedToken['payload']['given_names'] . ' ' . $decodedToken['payload']['family_name'];
+                // if $decodedToken['payload']['given_names'] is present use it or else only use $decodedToken['payload']['family_name']
+                $decodedToken['payload']['name'] = isset($decodedToken['payload']['given_names']) ? $decodedToken['payload']['given_names'] . ' ' . $decodedToken['payload']['family_name'] : $decodedToken['payload']['family_name'];
             }
         }
         if ($type === Role::Ministry_GUEST) {


### PR DESCRIPTION
This pull request makes a small improvement to the way student names are constructed in the `pdexLogin` method. The change ensures that if `given_names` is not present in the decoded token payload, only the `family_name` is used for the student's name, preventing potential errors or incomplete names.

- Improved logic for constructing the `name` field: Now uses only `family_name` if `given_names` is missing, instead of concatenating a missing value. (`app/Http/Controllers/UserController.php`, [app/Http/Controllers/UserController.phpL430-R431](diffhunk://#diff-8e91484f56a38d906339650a2e3af6dbda84b6a43e6d889b792bd55b53a54e76L430-R431))